### PR TITLE
Fix this bug with actionHandlers

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -145,13 +145,13 @@
       });
 
       if ('mediaSession' in navigator) {
-        navigator.mediaSession.setActionHandler("pause", () => {
+        navigator.mediaSession.setActionHandler("pause", function() {
           self.pauseTrack();
         });
-        navigator.mediaSession.setActionHandler("play", () => {
+        navigator.mediaSession.setActionHandler("play", function() {
           self.resumeTrack();
         });
-        navigator.mediaSession.setActionHandler("seekto", details => {
+        navigator.mediaSession.setActionHandler("seekto", function(details) {
           self.audioPlayer.currentTime = details.seekTime;
         });
       }


### PR DESCRIPTION
Convert media session action handlers from arrow functions to regular functions to fix `this` binding issues.

## Summary by Sourcery

Bug Fixes:
- Convert mediaSession action handlers from arrow functions to regular functions to ensure correct `this` binding